### PR TITLE
Configure session Lifespan to use access token age

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Make a copy of [NETID.example.yaml](NETID.example.yaml) to `./NETID.yaml` or `./
 
 #### Session 
 `SESSION_KEY`: Set the 32 byte cookie secret key. eg `openssl rand -base64 32 | head -c 32; echo`  
+`SESSION_AGE`: Optional, defaults to access token lifespan. Set the maximum age of a session before the user must reauthenticate  
 
 #### Hostname and Port
 `SERVER_PORT`: What port on localhost Go should listen to  

--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -47,6 +47,9 @@ func MarshallUserInfo(w http.ResponseWriter, r *http.Request, tokens *oidc.Token
 	}
 
 	var session_age = int(tokens.ExpiresIn)
+	if viper.IsSet("SESSION_AGE") {
+		session_age = viper.GetInt("SESSION_AGE")
+	}
 
 	session_IDCLAIM_IDENTITY, _ := SessionCookieStore.Get(r, "IDCLAIM_IDENTITY")
 	session_IDCLAIM_IDENTITY.Options = &sessions.Options{


### PR DESCRIPTION
- Adds configuration for session lifespan `SESSION_AGE`
- Changes default session age to OpenID Connect access token age

Closes #4 